### PR TITLE
Load configure file from git repository root

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -52,8 +52,10 @@ Use "commitizen-go [command] --help" for more information about a command.
 ```
 
 ## Configure
-You can customize your commit type, items, and how to assemble these items through the configuration file.
-Configuration file path is `~/.git-czrc`, and the format is the same as the defaultConfig string in the file commit/defaultConfig.go.
+You can set configuration file that `.git-czrc` at repository root or home directory. (You can also add the extension to file, like `.git-czrc.json`)
+The configure file that located in repository root have a priority over the one in home directory.
+The format is the same as the defaultConfig string in the file [commit/defaultConfig.go](https://github.com/lintingzhen/commitizen-go/blob/master/commit/defaultConfig.go).
+
 Type item like that:
 ```
 ...

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/integralist/go-findroot/find"
 	"github.com/lintingzhen/commitizen-go/commit"
 	"github.com/lintingzhen/commitizen-go/git"
 	homedir "github.com/mitchellh/go-homedir"
@@ -53,27 +54,35 @@ func initConfig() {
 	}
 
 	// Find home directory.
-	if home, err := homedir.Dir(); err != nil {
+	home, err := homedir.Dir()
+	if err != nil {
 		log.Printf("Get home dir failed, err=%v\n", err)
 		os.Exit(1)
-	} else {
-		// Search config in home directory with name ".git-czrc" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigName(".git-czrc")
-		viper.SetConfigType("json")
-
-		if err := viper.ReadInConfig(); err != nil {
-			if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-				// Config file not found; ignore error if desired
-				log.Printf("can not find config file\n")
-			} else {
-				// Config file was found but another error was produced
-				log.Printf("read config failed, err=%v\n", err)
-			}
-		} else {
-			log.Printf("read config success\n")
-		}
 	}
+	stat, err := find.Repo()
+	if err != nil {
+		log.Printf("Get git repository root failed, err=%v\n", err)
+		os.Exit(1)
+	}
+
+	// Search config in home directory and repository root directory with name ".git-czrc" (without extension).
+	viper.AddConfigPath(stat.Path)
+	viper.AddConfigPath(home)
+	viper.SetConfigName(".git-czrc")
+	viper.SetConfigType("json")
+
+	if err := viper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			// Config file not found; ignore error if desired
+			log.Printf("can not find config file\n")
+		} else {
+			// Config file was found but another error was produced
+			log.Printf("read config failed, err=%v\n", err)
+		}
+	} else {
+		log.Printf("read config success\n")
+	}
+
 }
 
 func RootCmd(command *cobra.Command, args []string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,7 +65,7 @@ func initConfig() {
 		os.Exit(1)
 	}
 
-	// Search config in home directory and repository root directory with name ".git-czrc" (without extension).
+	// Search config in home directory and repository root directory with name ".git-czrc" or ".git-czrc.json".
 	viper.AddConfigPath(stat.Path)
 	viper.AddConfigPath(home)
 	viper.SetConfigName(".git-czrc")

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.2
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/integralist/go-findroot v0.0.0-20160518114804-ac90681525dc // indirect
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174 h1:WlZsjVhE8Af9IcZDG
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/integralist/go-findroot v0.0.0-20160518114804-ac90681525dc h1:4IZpk3M4m6ypx0IlRoEyEyY1gAdicWLMQ0NcG/gBnnA=
+github.com/integralist/go-findroot v0.0.0-20160518114804-ac90681525dc/go.mod h1:UlaC6ndby46IJz9m/03cZPKKkR9ykeIVBBDE3UDBdJk=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=


### PR DESCRIPTION
# Overview

Added the ability to load settings from `git-czrc` in the root of the Git repository; if `git-czrc` is found in both the home directory and the Git repository, the Git repository searched first takes priority.

- This feature allows you to use different configuration files for different Git repositories.
- Related documentation corrections have been added.

# Issues
close #16